### PR TITLE
fix typos

### DIFF
--- a/content/clang-vectors.md
+++ b/content/clang-vectors.md
@@ -259,8 +259,8 @@ How is it possible for `f32x8_inc_neon` to
 have its argument and return value pass solely through registers
 even though they both have a size of 32 bytes?
 Well, it turns out that the AAPCS64
-makes an exception for "Homogeneous Floating-Point Aggregates” (HFAs)
-and "Homogeneous Short-Vector Aggregates” (HVAs).
+makes an exception for “Homogeneous Floating-Point Aggregates” (HFAs)
+and “Homogeneous Short-Vector Aggregates” (HVAs).
 These are either arrays or structs where each member has the same type;
 this type is a floating-point number in the case of an HFA,
 or a short vector in the case of an HVA.

--- a/content/clang-vectors.md
+++ b/content/clang-vectors.md
@@ -5,7 +5,7 @@ date: "2024-10-15"
 
 In a [previous post](/vector-types/) I mentioned Clang’s OpenCL vector extension.
 Since then I’ve continued playing around with AppKit and Metal programming,
-and my enthusiam for Clang’s OpenCL vectors has only grown since.
+and my enthusiasm for Clang’s OpenCL vectors has only grown since.
 
 It’s often necessary to specify two-dimensional values when doing GUI programming.
 Apple’s frameworks for making GUIs (AppKit, Core Graphics, Core Text, etc)
@@ -259,8 +259,8 @@ How is it possible for `f32x8_inc_neon` to
 have its argument and return value pass solely through registers
 even though they both have a size of 32 bytes?
 Well, it turns out that the AAPCS64
-makes an exception for “Homogenous Floating-Point Aggregates” (HFAs)
-and “Homogenous Short-Vector Aggregates” (HVAs).
+makes an exception for Homogeneous Floating-Point Aggregates” (HFAs)
+and Homogeneous Short-Vector Aggregates” (HVAs).
 These are either arrays or structs where each member has the same type;
 this type is a floating-point number in the case of an HFA,
 or a short vector in the case of an HVA.

--- a/content/clang-vectors.md
+++ b/content/clang-vectors.md
@@ -259,8 +259,8 @@ How is it possible for `f32x8_inc_neon` to
 have its argument and return value pass solely through registers
 even though they both have a size of 32 bytes?
 Well, it turns out that the AAPCS64
-makes an exception for Homogeneous Floating-Point Aggregates” (HFAs)
-and Homogeneous Short-Vector Aggregates” (HVAs).
+makes an exception for "Homogeneous Floating-Point Aggregates” (HFAs)
+and "Homogeneous Short-Vector Aggregates” (HVAs).
 These are either arrays or structs where each member has the same type;
 this type is a floating-point number in the case of an HFA,
 or a short vector in the case of an HVA.

--- a/content/const-pointers.md
+++ b/content/const-pointers.md
@@ -267,7 +267,7 @@ a feature of the hardware we’re writing our code for:
 the CPU’s memory management unit, or MMU,
 lets us specify the _protection_ for our memory.
 You can think of memory protection like Unix file permissions,
-but with three bits instead of three bytes:
+but with three bits instead of three octets:
 a bit for the ability to read from memory (`PROT_READ`),
 a bit for the ability to write to memory (`PROT_WRITE`),
 and a bit the ability to execute code stored in memory (`PROT_EXEC`).

--- a/content/const-pointers.md
+++ b/content/const-pointers.md
@@ -267,7 +267,7 @@ a feature of the hardware we’re writing our code for:
 the CPU’s memory management unit, or MMU,
 lets us specify the _protection_ for our memory.
 You can think of memory protection like Unix file permissions,
-but with three bits instead of three octects:
+but with three bits instead of three bytes:
 a bit for the ability to read from memory (`PROT_READ`),
 a bit for the ability to write to memory (`PROT_WRITE`),
 and a bit the ability to execute code stored in memory (`PROT_EXEC`).

--- a/content/macos-tips.md
+++ b/content/macos-tips.md
@@ -83,7 +83,7 @@ Rather than something special unto themselves,
 context menus merely display the small subset of menu items
 immediately relevant to whatever object you right-clicked.
 This results in the nice property that
-users can explore what capabilites an app has
+users can explore what capabilities an app has
 just by browsing through the menu items in the menu bar,
 which is always in the same easy-to-reach place on the display
 and always has the same contents for a given app,

--- a/content/rounding-up.md
+++ b/content/rounding-up.md
@@ -203,7 +203,7 @@ See, A64 has an instruction called Bitwise Bit Clear (or `bic` for short)
 specifically for zeroing out an integer `x`
 at the bit positions where bits are set in another integer `y`.
 In other words, it performs `x & ~y` in one go.
-By merging the calculation of `mask` with the calcuation of its complement,
+By merging the calculation of `mask` with the calculation of its complement,
 the compiler has missed an opportunity to use `bic`.
 I compiled several versions of the function hoping to get Clang to emit `bic`,
 but to no avail :(


### PR DESCRIPTION
Found with

cargo install typos

typos --exclude content/vector-types.md --exclude .ontent/n-times-faster.md